### PR TITLE
issue7 next-once

### DIFF
--- a/__mocks__/express/lib/router/layer.js
+++ b/__mocks__/express/lib/router/layer.js
@@ -1,0 +1,1 @@
+module.exports = function LayerMock() {}

--- a/lib/handle.js
+++ b/lib/handle.js
@@ -1,7 +1,16 @@
-const Layer = require('express/lib/router/layer')
 const wrap = require('./wrap')
 
-module.exports = (options = {}) => {
+let options
+let propertyDefined = false
+
+module.exports = (newOptions = {}) => {
+  options = newOptions
+  if (propertyDefined) {
+    return
+  }
+  propertyDefined = true
+  
+  const Layer = require('express/lib/router/layer')
   Object.defineProperty(Layer.prototype, "handle", {
     enumerable: true,
     get: function() { return this.__handle; },

--- a/lib/handle.js
+++ b/lib/handle.js
@@ -1,12 +1,14 @@
 const Layer = require('express/lib/router/layer')
 const wrap = require('./wrap')
 
-const _layer = Object.defineProperty(Layer.prototype, "handle", {
-  enumerable: true,
-  get: function() { return this.__handle; },
-  set: function(fn) { 
-    if(fn.length < 4)
-      fn = wrap(fn)
-    this.__handle = fn
-  }
-});
+module.exports = (options = {}) => {
+  Object.defineProperty(Layer.prototype, "handle", {
+    enumerable: true,
+    get: function() { return this.__handle; },
+    set: function(fn) { 
+      if (fn.length < 4)
+        fn = wrap(fn, options)
+      this.__handle = fn
+    }
+  })
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const exception = require('./custom-exception')
 const middleware = require('./middleware')
 const wrap = require('./wrap')
-const handle = () => { require('./handle') }
+const handle = require('./handle')
 
 module.exports = { exception, middleware, wrap, handle }

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -1,21 +1,21 @@
 const AppError = require('./custom-exception')
 
-function wrap(fn) {
+function wrap(fn, options = {}) {
   return (req, res, next) => {
-      try {
-            const routePromise = fn(req, res, next)
-            if (routePromise && routePromise.catch)
-                routePromise.catch(err => continueToErrorMiddleware(err, next))
-      } catch (err) {
-            continueToErrorMiddleware(err, next)
-      }
+    try {
+      const routePromise = fn(req, res, next)
+      if (routePromise && routePromise.catch)
+      routePromise.catch(err => continueToErrorMiddleware(err, next))
+    } catch (err) {
+      continueToErrorMiddleware(err, next)
     }
+  }
 };
 
 function continueToErrorMiddleware(err, next){
-    if(!err || !(err instanceof AppError) )
-        err = new AppError(err)
-    next(err)
+  if (!err || !(err instanceof AppError))
+    err = new AppError(err)
+  next(err)
 }
 
 module.exports = wrap

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -1,7 +1,23 @@
 const AppError = require('./custom-exception')
 
+const defaultOptions = {
+  nextOnce: true
+}
+
 function wrap(fn, options = {}) {
+  const fullOptions = { ...defaultOptions, ...options };
   return (req, res, next) => {
+    if (fullOptions.nextOnce) {
+      const originalNext = next
+      let nextCalled = false
+      next = (...args) => {
+        if (nextCalled) {
+          return;
+        }
+        nextCalled = true
+        originalNext(...args)
+      }
+    }
     try {
       const routePromise = fn(req, res, next)
       if (routePromise && routePromise.catch)

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -20,8 +20,9 @@ function wrap(fn, options = {}) {
     }
     try {
       const routePromise = fn(req, res, next)
-      if (routePromise && routePromise.catch)
-      routePromise.catch(err => continueToErrorMiddleware(err, next))
+      if (routePromise && routePromise.catch) {
+        routePromise.catch(err => continueToErrorMiddleware(err, next))
+      }
     } catch (err) {
       continueToErrorMiddleware(err, next)
     }

--- a/test/handle-test.js
+++ b/test/handle-test.js
@@ -1,0 +1,13 @@
+var handle = require('../lib/handle')
+
+describe('test handle', () => {
+    test('handle is called without throwing error', () => {
+        jest.mock('express/lib/router/layer')
+        handle()
+        var Layer = require('express/lib/router/layer')
+        var stubHandle = () => {}
+        Layer.prototype.handle = stubHandle
+        expect(Layer.prototype.handle).toBe(Layer.prototype.__handle)
+        handle() // call again to check there are no exceptions
+    })
+})

--- a/test/wrap-test.js
+++ b/test/wrap-test.js
@@ -39,4 +39,27 @@ describe('test the handle', () => {
         expect(next.mock.calls[0][0].response).toBe(error.response)
     })
 
+    test('wrap next once enabled', async () => {
+        var func = jest.fn((req, res, next) => {
+            next("something1") // This direct call will not be wrapped with AppError
+            return Promise.reject("something2")
+        })
+        var next = jest.fn()
+        var result = await wrap(func)(undefined,undefined,next)
+        expect(next.mock.calls.length).toBe(1)
+        expect(next.mock.calls[0][0]).toBe("something1")
+    })
+
+    test('wrap next once disabled', async () => {
+        var func = jest.fn((req, res, next) => {
+            next("something1") // This direct call will not be wrapped with AppError
+            return Promise.reject("something2")
+        })
+        var next = jest.fn()
+        var result = await wrap(func, { nextOnce: false })(undefined,undefined,next)
+        expect(next.mock.calls.length).toBe(2)
+        expect(next.mock.calls[0][0]).toBe("something1")
+        expect(next.mock.calls[1][0].message).toBe("something2")
+        expect(next.mock.calls[1][0].status).toBe(500)
+    })
 })


### PR DESCRIPTION
https://github.com/kanekotic/express-exception-handler/issues/7

handle function accepts options, once of them is `nextOnce` (true by default) which limits the original next-function to be called only once.

pull-request https://github.com/kanekotic/express-exception-handler/pull/9 includes all these changes plus the default-json-response changes